### PR TITLE
Fixed bug with second Python example

### DIFF
--- a/tutorial/second_example/wordcount.py
+++ b/tutorial/second_example/wordcount.py
@@ -11,9 +11,9 @@ if __name__ == "__main__":
     sc = SparkContext(appName="PythonWordCount")
     common_words = ["the", "a", "an", "and", "of", "to", "in", "am", "is", "are", "at", "not"]
     lines = sc.textFile(sys.argv[1], 1)
-    counts = lines.flatMap(lambda x: re.split(r"[ \t,;\.\?!-:@\[\]\(\){}_\*/]+", x)) \
+    counts = lines.flatMap(lambda x: re.split("[ \t,;\.\?!-:@\[\]\(\){}_\*/]+", x)) \
                   .filter(lambda x: x.lower() not in common_words and len(x) > 0) \
                   .map(lambda x: (x, 1)) \
                   .reduceByKey(add)
-
+    counts.saveAsTextFile(sys.argv[2])
     sc.stop()


### PR DESCRIPTION
The `wordcount.py`script used for the second example in the Spark tutorial will not run because of:
- a typo in the regular expression split
- a missing line to save the output

These are fixed here.
